### PR TITLE
Fix composition text color

### DIFF
--- a/src/ImeModule.cpp
+++ b/src/ImeModule.cpp
@@ -69,10 +69,10 @@ ImeModule::ImeModule(HMODULE module, const CLSID& textServiceClsid):
 
     // regiser default display attributes
     inputAttrib_ = ComPtr<DisplayAttributeInfo>::make(g_inputDisplayAttributeGuid);
-    inputAttrib_->setTextSysColor(COLOR_WINDOWTEXT);
+    inputAttrib_->setTextSysColor(COLOR_HIGHLIGHTTEXT);
     inputAttrib_->setBackgroundSysColor(COLOR_WINDOW);
     inputAttrib_->setLineStyle(TF_LS_DOT);
-    inputAttrib_->setLineSysColor(COLOR_WINDOWTEXT);
+    inputAttrib_->setLineSysColor(COLOR_HIGHLIGHTTEXT);
     displayAttrInfos_.push_back(inputAttrib_);
     // convertedAttrib_ = new DisplayAttributeInfo(g_convertedDisplayAttributeGuid);
     // displayAttrInfos_.push_back(convertedAttrib_);

--- a/src/ImeModule.cpp
+++ b/src/ImeModule.cpp
@@ -69,10 +69,7 @@ ImeModule::ImeModule(HMODULE module, const CLSID& textServiceClsid):
 
     // regiser default display attributes
     inputAttrib_ = ComPtr<DisplayAttributeInfo>::make(g_inputDisplayAttributeGuid);
-    inputAttrib_->setTextSysColor(COLOR_HIGHLIGHTTEXT);
-    inputAttrib_->setBackgroundSysColor(COLOR_WINDOW);
     inputAttrib_->setLineStyle(TF_LS_DOT);
-    inputAttrib_->setLineSysColor(COLOR_HIGHLIGHTTEXT);
     displayAttrInfos_.push_back(inputAttrib_);
     // convertedAttrib_ = new DisplayAttributeInfo(g_convertedDisplayAttributeGuid);
     // displayAttrInfos_.push_back(convertedAttrib_);


### PR DESCRIPTION
這個 PR 是為了修正 https://github.com/EasyIME/PIME/issues/698 ，把兩個參數修改之後，用編譯出來的 PIMETextService.dll 取代掉原本的檔案測試執行真的可以正確輸入：

![image](https://user-images.githubusercontent.com/39870664/202385641-22369351-00e3-469c-997f-93fe64a2d8d8.png)

或者在 VS Code 當中輸入時也會跟當前的程式碼顏色一致：

![image](https://user-images.githubusercontent.com/39870664/202385901-0b472850-13b8-4cc5-97d4-cf548df0e34b.png)
